### PR TITLE
Network explorer components in host

### DIFF
--- a/gc-merge-devnet-3/inventory/group_vars/all.yaml
+++ b/gc-merge-devnet-3/inventory/group_vars/all.yaml
@@ -106,6 +106,8 @@ eth1_metrics_port: 8002
 eth_metrics_exporter_port: 8003
 cadvisor_port: 9280
 promtail_port: 9080
+public_execution_explorer: 3334
+public_beacon_explorer: 3333
 
 ##############################################
 # Command for JSON RPC snooper
@@ -170,6 +172,8 @@ firewall_allowed_tcp_ports:
   - 9000
   - 80
   - 443
+  - "{{public_execution_explorer}}"
+  - "{{public_beacon_explorer}}"
 
 firewall_allowed_udp_ports:
   - 30303

--- a/gc-merge-devnet-3/inventory/group_vars/explorer.yml
+++ b/gc-merge-devnet-3/inventory/group_vars/explorer.yml
@@ -16,7 +16,7 @@ explorer_postgres_container_name: postgres
 explorer_postgres_image_name: "postgres:12.0"
 explorer_postgres_memory: 9000m
 explorer_postgres_port: "5432"
-explorer_postgres_ip: "172.1.1.100"
+explorer_postgres_ip: "127.0.0.1"
 explorer_postgres_user: postgres
 
 # Set in secrets.yaml

--- a/playbooks/tasks/start_beacon_explorer.yml
+++ b/playbooks/tasks/start_beacon_explorer.yml
@@ -1,6 +1,6 @@
 - name: Start explorer
   hosts: explorer
-  gather_facts: true
+  gather_facts: false
   serial: 20
   tasks:
     - name: Start Eth2 explorer
@@ -10,13 +10,10 @@
         image: "{{ beacon_explorer_image_name }}"
         pull: true
         restart_policy: unless-stopped
-        network_mode: bridge
-        networks:
-          - name: "{{explorer_docker_network_name}}"
-            ipv4_address: "172.1.1.101"
+        network_mode: host
         ports:
           - "5000:9333"
-          - "3333:3333"
+          - "{{public_beacon_explorer}}:3333"
         restart: "{{ explorer_require_restart | default(false) }}"
         memory: "{{explorer_memory}}"
         command: "{{ beacon_explorer_start_args }}"

--- a/playbooks/tasks/start_execution_explorer.yml
+++ b/playbooks/tasks/start_execution_explorer.yml
@@ -1,6 +1,6 @@
 - name: Start execution explorer
   hosts: explorer
-  gather_facts: true
+  gather_facts: false
   serial: 20
   tasks:
     - name: Start execution explorer
@@ -10,12 +10,9 @@
         image: "{{ execution_explorer_image_name }}"
         pull: true
         restart_policy: unless-stopped
-        network_mode: bridge
-        networks:
-          - name: "{{explorer_docker_network_name}}"
-            ipv4_address: "172.1.1.102"
+        network_mode: host
         ports:
-          - "3334:4000"
+          - "{{public_execution_explorer}}:4000"
         restart: "{{ explorer_require_restart | default(false) }}"
         memory: "{{explorer_memory}}"
         command: "{{ execution_explorer_start_args }}"

--- a/playbooks/tasks/start_explorer_postgres.yml
+++ b/playbooks/tasks/start_explorer_postgres.yml
@@ -1,6 +1,6 @@
 - name: Start explorer postgres db
   hosts: explorer
-  gather_facts: true
+  gather_facts: false
   serial: 20
   tasks:
     - name: Create postgres storage dir
@@ -15,10 +15,7 @@
         image: "{{ explorer_postgres_image_name }}"
         pull: true
         restart_policy: unless-stopped
-        network_mode: bridge
-        networks:
-          - name: "{{explorer_docker_network_name}}"
-            ipv4_address: "{{explorer_postgres_ip}}"
+        network_mode: host
         expose:
           - "{{explorer_postgres_port}}"
         restart: "{{ explorer_postgres_require_restart | default(false) }}"

--- a/playbooks/tasks/start_explorer_statistics.yml
+++ b/playbooks/tasks/start_explorer_statistics.yml
@@ -1,6 +1,6 @@
 - name: Start explorer statistics
   hosts: explorer
-  gather_facts: true
+  gather_facts: false
   serial: 20
   tasks:
     - name: Start Eth2 explorer statistics
@@ -10,10 +10,7 @@
         image: "{{ beacon_explorer_image_name }}"
         pull: true
         restart_policy: unless-stopped
-        network_mode: bridge
-        networks:
-          - name: "{{explorer_docker_network_name}}"
-            ipv4_address: "172.1.1.104"
+        network_mode: host
         restart: "{{ explorer_stats_require_restart | default(false) }}"
         command: "{{ explorer_stats_start_args }}"
         volumes: "{{explorer_stats_volumes}}"

--- a/playbooks/tasks/templates/blockscout_data/blockscout.env.j2
+++ b/playbooks/tasks/templates/blockscout_data/blockscout.env.j2
@@ -18,6 +18,7 @@ SUBNETWORK=Testnet
 BLOCK_TRANSFORMER=base
 POOL_SIZE=15
 CHAIN_SPEC_PATH={{execution_explorer_genesis_cont_path}}
+PORT={{public_execution_explorer}}
 {% if explorer_first_block is defined %}
 FIRST_BLOCK={{explorer_first_block}}
 TRACE_FIRST_BLOCK={{explorer_first_block}}


### PR DESCRIPTION
Closes https://github.com/gnosischain/consensus-deployment-ansible/issues/15

The issue with explorers is they couldn't reach the local nodes @giacomolicari @riccardo-gnosis changed networking to all live in host instead of a dedicated bridge network. Could you review if that's fine? The firewall should offer some protection to the explorer's components.