### PR TITLE
Setup chown to permissions on beacon chain path

### DIFF
--- a/playbooks/tasks/start_beacon.yml
+++ b/playbooks/tasks/start_beacon.yml
@@ -6,9 +6,9 @@
       file:
         path: "{{beacon_node_dir}}"
         state: directory
-    # - name: Modify permissions to match user-group inside docker image
-    #   shell: chown -R "{{ beacon_user_id }}" "{{ beacon_node_dir }}"
-    #   become: true
+    - name: Modify permissions to match user-group inside docker image
+      shell: chown -R "{{ beacon_user_id }}" "{{ beacon_node_dir }}"
+      become: true
     - name: Start Eth2 beacon node container
       docker_container:
         name: "{{ beacon_container_name }}"


### PR DESCRIPTION
 - Recursive `chown` is required for the beacon chain node
   directory inside docker image.