### PR TITLE
Improve Archive node capabilities on EL by configuration parameters

### DIFF
--- a/chiado/inventory/group_vars/eth1client_nethermind.yml
+++ b/chiado/inventory/group_vars/eth1client_nethermind.yml
@@ -64,10 +64,13 @@ eth1_start_args: >
   --KeyStore.KeyStoreDirectory=/networkdata/miner_keystores
   --KeyStore.UnlockAccounts={{mining_addresses[mining_keyi]}}
   {% endif %}
-  {% if (prunning_none is defined) and prunning_none %}
+  {% if (el_archive_config is defined) and el_archive_config %}
   --Pruning.Mode=None
-  {% endif %}
+  --Sync.FastSync=false
+  {% else %}
   --Sync.FastSync=true
+  {% endif %}
+
 
 # run as root, the nethermind image doesn't handle running regular user well
 eth1_user_id: "0:0"

--- a/chiado/inventory/inventory.ini
+++ b/chiado/inventory/inventory.ini
@@ -1,48 +1,49 @@
-chiado-lighthouse-nethermind-00  ansible_host=68.183.83.184   mining_keyi=0  mnemonic={{mnemonic_4}} indexes=0000..1000  host=do_s-8vcpu-16gb-amd
-chiado-lighthouse-nethermind-01  ansible_host=159.203.36.192  mining_keyi=1  mnemonic={{mnemonic_4}} indexes=1000..2000  host=do_s-8vcpu-16gb-amd
-chiado-lighthouse-nethermind-02  ansible_host=159.203.39.74   mining_keyi=2  mnemonic={{mnemonic_4}} indexes=2000..3000  host=do_s-8vcpu-16gb-amd
-chiado-lighthouse-nethermind-03  ansible_host=159.223.38.196  mining_keyi=3  mnemonic={{mnemonic_4}} indexes=3000..4000  host=do_s-8vcpu-16gb-amd
-chiado-lighthouse-nethermind-04  ansible_host=159.223.51.175  mining_keyi=4  mnemonic={{mnemonic_4}} indexes=4000..5000  host=do_s-8vcpu-16gb-amd
-chiado-lighthouse-nethermind-05  ansible_host=188.166.110.195 mining_keyi=5  mnemonic={{mnemonic_4}} indexes=5000..6000  host=do_s-8vcpu-16gb-amd
-chiado-lighthouse-nethermind-06  ansible_host=142.93.128.87   mining_keyi=6  mnemonic={{mnemonic_4}} indexes=6000..7000  host=do_s-8vcpu-16gb-amd
-chiado-lighthouse-nethermind-07  ansible_host=147.182.210.97  mining_keyi=7  mnemonic={{mnemonic_4}} indexes=7000..8000  host=do_s-8vcpu-16gb-amd
-chiado-lighthouse-nethermind-08  ansible_host=142.93.198.90   mining_keyi=8  mnemonic={{mnemonic_4}} indexes=8000..9000  host=do_s-8vcpu-16gb-amd
-chiado-lighthouse-nethermind-09  ansible_host=142.93.126.246  mining_keyi=9  mnemonic={{mnemonic_4}} indexes=9000..10000 host=do_s-8vcpu-16gb-amd
-chiado-prysm-nethermind-00  ansible_host=68.183.5.97      mnemonic={{mnemonic_5}} indexes=0000..1000                     host=do_s-8vcpu-16gb-amd
-chiado-prysm-nethermind-01  ansible_host=146.190.17.210   mnemonic={{mnemonic_5}} indexes=1000..2000                     host=do_s-8vcpu-16gb-amd
-chiado-prysm-nethermind-02  ansible_host=134.209.200.153  mnemonic={{mnemonic_5}} indexes=2000..3000                     host=do_s-8vcpu-16gb-amd
-chiado-prysm-nethermind-03  ansible_host=134.209.82.117   mnemonic={{mnemonic_5}} indexes=3000..4000                     host=do_s-8vcpu-16gb-amd
-chiado-prysm-nethermind-04  ansible_host=134.209.198.195  mnemonic={{mnemonic_5}} indexes=4000..5000                     host=do_s-8vcpu-16gb-amd
-chiado-prysm-nethermind-05  ansible_host=104.248.87.225   mnemonic={{mnemonic_5}} indexes=5000..6000  prunning_none=true host=do_s-8vcpu-16gb-amd
-chiado-prysm-nethermind-06  ansible_host=134.209.202.76   mnemonic={{mnemonic_5}} indexes=6000..7000  prunning_none=true host=do_s-8vcpu-16gb-amd
-chiado-prysm-nethermind-07  ansible_host=134.209.202.214  mnemonic={{mnemonic_5}} indexes=7000..8000  prunning_none=true host=do_s-8vcpu-16gb-amd
-chiado-prysm-nethermind-08  ansible_host=134.209.202.136  mnemonic={{mnemonic_5}} indexes=8000..9000  prunning_none=true host=do_s-8vcpu-16gb-amd
-chiado-prysm-nethermind-09  ansible_host=134.209.206.142  mnemonic={{mnemonic_5}} indexes=9000..10000 prunning_none=true host=do_s-8vcpu-16gb-amd
-chiado-teku-nethermind-00   ansible_host=143.198.110.93   mnemonic={{mnemonic_8}}  indexes=0000..1000                    host=do_s-8vcpu-16gb-amd
-chiado-teku-nethermind-01   ansible_host=147.182.192.131  mnemonic={{mnemonic_9}}  indexes=0000..1000                    host=do_s-8vcpu-16gb-amd
-chiado-teku-nethermind-02   ansible_host=143.244.191.48   mnemonic={{mnemonic_10}} indexes=0000..1000                    host=do_s-8vcpu-16gb-amd
-chiado-teku-nethermind-03   ansible_host=143.244.191.132  mnemonic={{mnemonic_11}} indexes=0000..1000 prunning_none=true host=do_s-8vcpu-16gb-amd
-chiado-teku-nethermind-04   ansible_host=147.182.200.35   mnemonic={{mnemonic_12}} indexes=0000..1000 prunning_none=true host=do_s-8vcpu-16gb-amd
-chiado-teku-nethermind-05   ansible_host=143.244.191.146  mnemonic={{mnemonic_13}} indexes=0000..1000 prunning_none=true host=do_s-8vcpu-16gb-amd
-chiado-lodestar-nethermind-00   ansible_host=143.110.210.203   mnemonic={{mnemonic_14}} indexes=0300..1000               host=do_s-8vcpu-16gb-amd
-chiado-lodestar-nethermind-01   ansible_host=143.110.210.241   mnemonic={{mnemonic_15}} indexes=0300..1000               host=do_s-8vcpu-16gb-amd
-chiado-explorer-execution-lighthouse-nethermind ansible_host=18.185.94.132 prunning_none=true
-chiado-explorer-beacon-lighthouse-nethermind    ansible_host=3.123.1.80 prunning_none=true
+chiado-lighthouse-nethermind-00  ansible_host=68.183.83.184   mining_keyi=0  mnemonic={{mnemonic_4}} indexes=0000..1000      host=do_s-8vcpu-16gb-amd
+chiado-lighthouse-nethermind-01  ansible_host=159.203.36.192  mining_keyi=1  mnemonic={{mnemonic_4}} indexes=1000..2000      host=do_s-8vcpu-16gb-amd
+chiado-lighthouse-nethermind-02  ansible_host=159.203.39.74   mining_keyi=2  mnemonic={{mnemonic_4}} indexes=2000..3000      host=do_s-8vcpu-16gb-amd
+chiado-lighthouse-nethermind-03  ansible_host=159.223.38.196  mining_keyi=3  mnemonic={{mnemonic_4}} indexes=3000..4000      host=do_s-8vcpu-16gb-amd
+chiado-lighthouse-nethermind-04  ansible_host=159.223.51.175  mining_keyi=4  mnemonic={{mnemonic_4}} indexes=4000..5000      host=do_s-8vcpu-16gb-amd
+chiado-lighthouse-nethermind-05  ansible_host=188.166.110.195 mining_keyi=5  mnemonic={{mnemonic_4}} indexes=5000..6000      host=do_s-8vcpu-16gb-amd
+chiado-lighthouse-nethermind-06  ansible_host=142.93.128.87   mining_keyi=6  mnemonic={{mnemonic_4}} indexes=6000..7000      host=do_s-8vcpu-16gb-amd
+chiado-lighthouse-nethermind-07  ansible_host=147.182.210.97  mining_keyi=7  mnemonic={{mnemonic_4}} indexes=7000..8000      host=do_s-8vcpu-16gb-amd
+chiado-lighthouse-nethermind-08  ansible_host=142.93.198.90   mining_keyi=8  mnemonic={{mnemonic_4}} indexes=8000..9000      host=do_s-8vcpu-16gb-amd
+chiado-lighthouse-nethermind-09  ansible_host=142.93.126.246  mining_keyi=9  mnemonic={{mnemonic_4}} indexes=9000..10000     host=do_s-8vcpu-16gb-amd
+chiado-prysm-nethermind-00  ansible_host=68.183.5.97      mnemonic={{mnemonic_5}} indexes=0000..1000                         host=do_s-8vcpu-16gb-amd
+chiado-prysm-nethermind-01  ansible_host=146.190.17.210   mnemonic={{mnemonic_5}} indexes=1000..2000                         host=do_s-8vcpu-16gb-amd
+chiado-prysm-nethermind-02  ansible_host=134.209.200.153  mnemonic={{mnemonic_5}} indexes=2000..3000                         host=do_s-8vcpu-16gb-amd
+chiado-prysm-nethermind-03  ansible_host=134.209.82.117   mnemonic={{mnemonic_5}} indexes=3000..4000                         host=do_s-8vcpu-16gb-amd
+chiado-prysm-nethermind-04  ansible_host=134.209.198.195  mnemonic={{mnemonic_5}} indexes=4000..5000                         host=do_s-8vcpu-16gb-amd
+chiado-prysm-nethermind-05  ansible_host=104.248.87.225   mnemonic={{mnemonic_5}} indexes=5000..6000  el_archive_config=true host=do_s-8vcpu-16gb-amd
+chiado-prysm-nethermind-06  ansible_host=134.209.202.76   mnemonic={{mnemonic_5}} indexes=6000..7000  el_archive_config=true host=do_s-8vcpu-16gb-amd
+chiado-prysm-nethermind-07  ansible_host=134.209.202.214  mnemonic={{mnemonic_5}} indexes=7000..8000  el_archive_config=true host=do_s-8vcpu-16gb-amd
+chiado-prysm-nethermind-08  ansible_host=134.209.202.136  mnemonic={{mnemonic_5}} indexes=8000..9000  el_archive_config=true host=do_s-8vcpu-16gb-amd
+chiado-prysm-nethermind-09  ansible_host=134.209.206.142  mnemonic={{mnemonic_5}} indexes=9000..10000 el_archive_config=true host=do_s-8vcpu-16gb-amd
+chiado-teku-nethermind-00   ansible_host=143.198.110.93   mnemonic={{mnemonic_8}}  indexes=0000..1000                        host=do_s-8vcpu-16gb-amd
+chiado-teku-nethermind-01   ansible_host=147.182.192.131  mnemonic={{mnemonic_9}}  indexes=0000..1000                        host=do_s-8vcpu-16gb-amd
+chiado-teku-nethermind-02   ansible_host=143.244.191.48   mnemonic={{mnemonic_10}} indexes=0000..1000                        host=do_s-8vcpu-16gb-amd
+chiado-teku-nethermind-03   ansible_host=143.244.191.132  mnemonic={{mnemonic_11}} indexes=0000..1000 el_archive_config=true host=do_s-8vcpu-16gb-amd
+chiado-teku-nethermind-04   ansible_host=147.182.200.35   mnemonic={{mnemonic_12}} indexes=0000..1000 el_archive_config=true host=do_s-8vcpu-16gb-amd
+chiado-teku-nethermind-05   ansible_host=143.244.191.146  mnemonic={{mnemonic_13}} indexes=0000..1000 el_archive_config=true host=do_s-8vcpu-16gb-amd
+chiado-lodestar-nethermind-00   ansible_host=143.110.210.203   mnemonic={{mnemonic_14}} indexes=0300..1000                   host=do_s-8vcpu-16gb-amd
+chiado-lodestar-nethermind-01   ansible_host=143.110.210.241   mnemonic={{mnemonic_15}} indexes=0300..1000                   host=do_s-8vcpu-16gb-amd
+# IMPORTANT: Please ask Gnosis DevOps prior to applying any changes on the explorer machines
+#chiado-explorer-execution-lighthouse-nethermind ansible_host=18.185.94.132 el_archive_config=true
+#chiado-explorer-beacon-lighthouse-nethermind    ansible_host=3.123.1.80 el_archive_config=true
 
 
 ; Check ../README.md for key distribution
 
 [explorer_execution]
-chiado-explorer-execution-lighthouse-nethermind
+#chiado-explorer-execution-lighthouse-nethermind
 
 [explorer_beacon]
-chiado-explorer-beacon-lighthouse-nethermind
+#chiado-explorer-beacon-lighthouse-nethermind
 
 [ethstats_server]
-chiado-explorer-beacon-lighthouse-nethermind
+#chiado-explorer-beacon-lighthouse-nethermind
 
 [forkmon]
-chiado-explorer-beacon-lighthouse-nethermind
+#chiado-explorer-beacon-lighthouse-nethermind
 
 ; NGINX with Certbot
 [reverse_proxy]
@@ -68,18 +69,18 @@ chiado-lighthouse-nethermind-07
 chiado-lighthouse-nethermind-08
 chiado-lighthouse-nethermind-09
 ; Temp, not able to produce blocks, not have good participation
-chiado-prysm-nethermind-00  
-chiado-prysm-nethermind-01  
-chiado-prysm-nethermind-02  
-chiado-prysm-nethermind-03  
-chiado-prysm-nethermind-04  
-chiado-prysm-nethermind-05  
-chiado-prysm-nethermind-06  
-chiado-prysm-nethermind-07  
-chiado-prysm-nethermind-08  
-chiado-prysm-nethermind-09  
-chiado-explorer-execution-lighthouse-nethermind
-chiado-explorer-beacon-lighthouse-nethermind
+chiado-prysm-nethermind-00
+chiado-prysm-nethermind-01
+chiado-prysm-nethermind-02
+chiado-prysm-nethermind-03
+chiado-prysm-nethermind-04
+chiado-prysm-nethermind-05
+chiado-prysm-nethermind-06
+chiado-prysm-nethermind-07
+chiado-prysm-nethermind-08
+chiado-prysm-nethermind-09
+#chiado-explorer-execution-lighthouse-nethermind
+#chiado-explorer-beacon-lighthouse-nethermind
 
 [eth2client_prysm]
 
@@ -109,15 +110,15 @@ chiado-lighthouse-nethermind-06
 chiado-lighthouse-nethermind-07
 chiado-lighthouse-nethermind-08
 chiado-lighthouse-nethermind-09
-chiado-prysm-nethermind-00  
-chiado-prysm-nethermind-01  
-chiado-prysm-nethermind-02  
-chiado-prysm-nethermind-03  
-chiado-prysm-nethermind-04  
-chiado-prysm-nethermind-05  
-chiado-prysm-nethermind-06  
-chiado-prysm-nethermind-07  
-chiado-prysm-nethermind-08  
+chiado-prysm-nethermind-00
+chiado-prysm-nethermind-01
+chiado-prysm-nethermind-02
+chiado-prysm-nethermind-03
+chiado-prysm-nethermind-04
+chiado-prysm-nethermind-05
+chiado-prysm-nethermind-06
+chiado-prysm-nethermind-07
+chiado-prysm-nethermind-08
 chiado-prysm-nethermind-09
 chiado-teku-nethermind-00
 chiado-teku-nethermind-01
@@ -127,8 +128,8 @@ chiado-teku-nethermind-04
 chiado-teku-nethermind-05
 chiado-lodestar-nethermind-00
 chiado-lodestar-nethermind-01
-chiado-explorer-execution-lighthouse-nethermind
-chiado-explorer-beacon-lighthouse-nethermind
+#chiado-explorer-execution-lighthouse-nethermind
+#chiado-explorer-beacon-lighthouse-nethermind
 
 
 ; eth1 eth2 groupings
@@ -144,15 +145,15 @@ chiado-lighthouse-nethermind-06
 chiado-lighthouse-nethermind-07
 chiado-lighthouse-nethermind-08
 chiado-lighthouse-nethermind-09
-chiado-prysm-nethermind-00  
-chiado-prysm-nethermind-01  
-chiado-prysm-nethermind-02  
-chiado-prysm-nethermind-03  
-chiado-prysm-nethermind-04  
-chiado-prysm-nethermind-05  
-chiado-prysm-nethermind-06  
-chiado-prysm-nethermind-07  
-chiado-prysm-nethermind-08  
+chiado-prysm-nethermind-00
+chiado-prysm-nethermind-01
+chiado-prysm-nethermind-02
+chiado-prysm-nethermind-03
+chiado-prysm-nethermind-04
+chiado-prysm-nethermind-05
+chiado-prysm-nethermind-06
+chiado-prysm-nethermind-07
+chiado-prysm-nethermind-08
 chiado-prysm-nethermind-09
 chiado-teku-nethermind-00
 chiado-teku-nethermind-01
@@ -162,8 +163,8 @@ chiado-teku-nethermind-04
 chiado-teku-nethermind-05
 chiado-lodestar-nethermind-00
 chiado-lodestar-nethermind-01
-chiado-explorer-execution-lighthouse-nethermind
-chiado-explorer-beacon-lighthouse-nethermind
+#chiado-explorer-execution-lighthouse-nethermind
+#chiado-explorer-beacon-lighthouse-nethermind
 
 [validator]
 chiado-lighthouse-nethermind-00
@@ -176,15 +177,15 @@ chiado-lighthouse-nethermind-06
 chiado-lighthouse-nethermind-07
 chiado-lighthouse-nethermind-08
 chiado-lighthouse-nethermind-09
-chiado-prysm-nethermind-00  
-chiado-prysm-nethermind-01  
-chiado-prysm-nethermind-02  
-chiado-prysm-nethermind-03  
-chiado-prysm-nethermind-04  
-chiado-prysm-nethermind-05  
-chiado-prysm-nethermind-06  
-chiado-prysm-nethermind-07  
-chiado-prysm-nethermind-08  
+chiado-prysm-nethermind-00
+chiado-prysm-nethermind-01
+chiado-prysm-nethermind-02
+chiado-prysm-nethermind-03
+chiado-prysm-nethermind-04
+chiado-prysm-nethermind-05
+chiado-prysm-nethermind-06
+chiado-prysm-nethermind-07
+chiado-prysm-nethermind-08
 chiado-prysm-nethermind-09
 chiado-teku-nethermind-00
 chiado-teku-nethermind-01
@@ -206,15 +207,15 @@ chiado-lighthouse-nethermind-06
 chiado-lighthouse-nethermind-07
 chiado-lighthouse-nethermind-08
 chiado-lighthouse-nethermind-09
-chiado-prysm-nethermind-00  
-chiado-prysm-nethermind-01  
-chiado-prysm-nethermind-02  
-chiado-prysm-nethermind-03  
-chiado-prysm-nethermind-04  
-chiado-prysm-nethermind-05  
-chiado-prysm-nethermind-06  
-chiado-prysm-nethermind-07  
-chiado-prysm-nethermind-08  
+chiado-prysm-nethermind-00
+chiado-prysm-nethermind-01
+chiado-prysm-nethermind-02
+chiado-prysm-nethermind-03
+chiado-prysm-nethermind-04
+chiado-prysm-nethermind-05
+chiado-prysm-nethermind-06
+chiado-prysm-nethermind-07
+chiado-prysm-nethermind-08
 chiado-prysm-nethermind-09
 chiado-teku-nethermind-00
 chiado-teku-nethermind-01
@@ -224,8 +225,8 @@ chiado-teku-nethermind-04
 chiado-teku-nethermind-05
 chiado-lodestar-nethermind-00
 chiado-lodestar-nethermind-01
-chiado-explorer-execution-lighthouse-nethermind
-chiado-explorer-beacon-lighthouse-nethermind
+#chiado-explorer-execution-lighthouse-nethermind
+#chiado-explorer-beacon-lighthouse-nethermind
 
 [secrets]
 chiado-lighthouse-nethermind-00
@@ -238,15 +239,15 @@ chiado-lighthouse-nethermind-06
 chiado-lighthouse-nethermind-07
 chiado-lighthouse-nethermind-08
 chiado-lighthouse-nethermind-09
-chiado-prysm-nethermind-00  
-chiado-prysm-nethermind-01  
-chiado-prysm-nethermind-02  
-chiado-prysm-nethermind-03  
-chiado-prysm-nethermind-04  
-chiado-prysm-nethermind-05  
-chiado-prysm-nethermind-06  
-chiado-prysm-nethermind-07  
-chiado-prysm-nethermind-08  
+chiado-prysm-nethermind-00
+chiado-prysm-nethermind-01
+chiado-prysm-nethermind-02
+chiado-prysm-nethermind-03
+chiado-prysm-nethermind-04
+chiado-prysm-nethermind-05
+chiado-prysm-nethermind-06
+chiado-prysm-nethermind-07
+chiado-prysm-nethermind-08
 chiado-prysm-nethermind-09
 chiado-teku-nethermind-00
 chiado-teku-nethermind-01
@@ -256,5 +257,5 @@ chiado-teku-nethermind-04
 chiado-teku-nethermind-05
 chiado-lodestar-nethermind-00
 chiado-lodestar-nethermind-01
-chiado-explorer-execution-lighthouse-nethermind
-chiado-explorer-beacon-lighthouse-nethermind
+#chiado-explorer-execution-lighthouse-nethermind
+#chiado-explorer-beacon-lighthouse-nethermind


### PR DESCRIPTION
Replace prunning_none with el_archive_config.
disable fastsync on archive mode.
Comment out explorer machines in the inventory.