### PR TITLE
Fix typo chmod

### DIFF
--- a/playbooks/tasks/upload_custom_config_data.yml
+++ b/playbooks/tasks/upload_custom_config_data.yml
@@ -37,5 +37,5 @@
         content: "{{keystores_password}}"
 
     - name: Modify permissions to match user-group inside docker image
-      shell: chown -R 777 "{{ testnet_dir }}"
+      shell: chmod -R 640 "{{ testnet_dir }}"
       become: true


### PR DESCRIPTION
  - Fix typo chown instead chmod.
  - Replace permissions to 640.