### PR TITLE
Update Denver Nethermind version

### DIFF
--- a/denver/inventory/group_vars/eth1client_nethermind.yml
+++ b/denver/inventory/group_vars/eth1client_nethermind.yml
@@ -1,6 +1,6 @@
 eth1_client_name: nethermind
 # Fixed image from Jul 29 2022 7AM UTC
-eth1_image_name: nethermindeth/nethermind:gnosis
+eth1_image_name: nethermindeth/nethermind:gnosis@sha256:a314367b0a217f498ca3ab2c9d0f0b9cf2021b259fd78b4e97d786d40953c25d
 execution_endpoint: http://127.0.0.1:{{eth1_engine_snoop_port}}
 snoop_command: "./json_rpc_snoop -p {{eth1_engine_snoop_port}} http://127.0.0.1:{{eth1_engine_port}}"
 

--- a/denver/inventory/inventory.ini
+++ b/denver/inventory/inventory.ini
@@ -1,5 +1,5 @@
-denver-explorer-lighthouse-nethermind ansible_host=3.126.84.57
-denver-explorer-eth2-lighthouse-nethermind ansible_host=18.196.125.204
+denver-explorer-lighthouse-nethermind ansible_host=18.194.165.73 disable_prunning=true
+denver-explorer-eth2-lighthouse-nethermind ansible_host=3.70.133.151
 denver-lighthouse-nethermind-00  ansible_host=137.184.147.72   mining_keyi=0  mnemonic={{mnemonic_0}} indexes=0000..1000
 denver-lighthouse-nethermind-01  ansible_host=137.184.196.49   mining_keyi=1  mnemonic={{mnemonic_0}} indexes=1000..2000
 denver-lighthouse-nethermind-02  ansible_host=159.223.196.208  mining_keyi=2  mnemonic={{mnemonic_0}} indexes=2000..3000

--- a/playbooks/tasks/templates/beaconchain_explorer/imprint.html
+++ b/playbooks/tasks/templates/beaconchain_explorer/imprint.html
@@ -6,7 +6,7 @@
 {{with .Data}}
 <div class="container mt-2">
     <h2>Merge testnet explorer!</h2><br/>
-    <h3>Fork of <a href="https://github.com/gobitfly/eth2-beaconchain-explorer">Eth2 beaconcha.in explorer</a>.</h3>
+    <h3>Fork of <a href="https://github.com/gobitfly/eth2-beaconchain-explorer">{{eth2_network_name}} beaconchain explorer</a>.</h3>
 </div><a href="/" class="btn btn-primary mt-4">Back</a>
 </div>
 {{end}}


### PR DESCRIPTION
  - Update Denver Nethermind to gnosis tag digest
    `a314367b0a217f498ca3ab2c9d0f0b9cf2021b259fd78b4e97d786d40953c25d`.
  - Add new machines to Denver inventory.
  - Enable archive mode in `denver-explorer-lighthouse-nethermind`.
  - Fix typo in beacon chain explorer imprint hml file.